### PR TITLE
docs: :pencil2: Use EvaKom instead of Evakom

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -2,7 +2,7 @@ project:
   type: sdca-theme
 
 website:
-  title: "Evakom"
+  title: "EvaKom"
   site-url: "https://steno-aarhus.github.io/evakom/"
   repo-url: "https://github.com/steno-aarhus/evakom"
   navbar:


### PR DESCRIPTION
@TinaQuist if you want to make some edits to the top navigation bar, the file `_quarto.yml` contains the settings to modify that. So the `title:` setting is the name on the top right corner of the website. I used `EvaKom` as you asked :relaxed: 