### PR TITLE
style: :lipstick: profile picture styling into it's own file

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -20,7 +20,9 @@ website:
         href: directory.qmd
         aria-label: "Globe icon: Link to directory page of other SDCA websites"
 
-format: sdca-theme-html
+format: 
+  sdca-theme-html:
+    css: style.css
 
 editor: 
   markdown:

--- a/index.qmd
+++ b/index.qmd
@@ -137,9 +137,9 @@ deltage?**</summary>
 
 ## Kontakt
 
+::: {layout-ncol="2"}
 ### Tina Quist
 
-::: {layout-ncol="2"}
 -   Projektleder og kontaktperson
 -   Mail: tina.quist\@rm.dk
 -   Tlf. 2434 6347

--- a/kontakt.qmd
+++ b/kontakt.qmd
@@ -2,22 +2,6 @@
 title: "Kontakt"
 ---
 
-```{=html}
-<style>
-.profile-picture {
-  display: inline-block;
-  border-radius: 50%;
-  object-fit: cover;
-  width: 200px;
-  height: 200px;
-}
-
-figcaption {
-  text-align: center;
-}
-</style>
-```
-
 ::: {layout-ncol="2"}
 ![Tina Quist](/images/tina.jpg){.profile-picture}
 

--- a/style.css
+++ b/style.css
@@ -1,0 +1,11 @@
+.profile-picture {
+  display: inline-block;
+  border-radius: 50%;
+  object-fit: cover;
+  width: 200px;
+  height: 200px;
+}
+
+figcaption {
+  text-align: center;
+}


### PR DESCRIPTION
@TinaQuist I moved the style text found in the `kontakt.qmd` file over into it's own file called `style.css`. CSS is the style "instructions" that browsers like Firefox or Edge or Chrome use to style items like text on the screen. Our CSS style instructions here are to set any image marked with `.profile-picture` so that it is a circle rather than a rectangle.

I moved it into it's own file, so that I could add it to the `_quarto.yml` settings to make the styles available to all pages on the website, not just the Kontakt one.

I also found a formatting issue, the `layout-ncol` block needed to start *above* your name to look as expected.

I'll let you merge this in :relaxed: 